### PR TITLE
Add GNOME 48 compatibility and release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build extension package
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare build
+        run: sudo apt-get update && sudo apt-get install -y zip
+
+      - name: Build extension archive
+        run: ./build.sh keyboard-cat-defense@onel.github.io.zip
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: auto-${{ github.sha }}
+          name: Auto build for ${{ github.sha }}
+          body: |
+            Automated build triggered by ${{ github.event_name }} on ${{ github.ref }}.
+          draft: false
+          prerelease: true
+          files: keyboard-cat-defense@onel.github.io.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT="${1:-keyboard-cat-defense@onel.github.io.zip}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+rm -f "$OUTPUT"
+
+zip -r "$OUTPUT" \
+    cat.svg \
+    extension.js \
+    metadata.json \
+    stylesheet.css \
+    README.md \
+    LICENSE \
+    -x 'keyboard-cat-defense@onel.github.io.zip' \
+    -x '*.git*' \
+    -x '.github/*' \
+    -x 'build.sh'

--- a/extension.js
+++ b/extension.js
@@ -1,167 +1,188 @@
-const { St, Gio, GObject, GLib, Shell, Clutter } = imports.gi
+import Clutter from 'gi://Clutter';
+import Gio from 'gi://Gio';
+import GLib from 'gi://GLib';
+import GObject from 'gi://GObject';
+import St from 'gi://St';
 
-const Me = imports.misc.extensionUtils.getCurrentExtension()
-const Main = imports.ui.main
-const PanelMenu = imports.ui.panelMenu
-const PopupMenu = imports.ui.popupMenu
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
 
-let KeyboardListMenu = GObject.registerClass(
-    class KeyboardListMenu extends PanelMenu.Button {
-        _init() {
-            super._init(0.0, "Keyboard cat defense")
+const UTF8_DECODER = new TextDecoder('utf-8');
 
-            // add main icon
-            let icon = new St.Icon({
-                gicon: Gio.icon_new_for_string(Me.path + "/cat.svg"),
-                style_class: 'cat-icon'
-            })
-            this.add_child(icon)
+function bytesToString(bytes) {
+    if (!bytes)
+        return '';
 
-            // even though we remove this item in _updateKeyboardList(), we need to add it
-            // if we don't, the dropdown menu won't open at all
-            this.menu.addMenuItem(new PopupMenu.PopupMenuItem('List of connected keyboards:'))
+    if (bytes instanceof GLib.Bytes || bytes?.toArray instanceof Function)
+        return UTF8_DECODER.decode(bytes.toArray());
 
-            this.menu.connect('open-state-changed', (menu, open) => {
-                // when opening for the first time
-                if (open && !this.initialized) {
-                    this._updateKeyboardList()
-                    this.initialized = true
-                }
-            })
-        }
+    if (bytes instanceof Uint8Array)
+        return UTF8_DECODER.decode(bytes);
 
-        /**
-         * Used to create the dropdown menu for the extensions
-         */
-        _updateKeyboardList() {
-            this.menu.removeAll()
+    if (bytes instanceof ArrayBuffer)
+        return UTF8_DECODER.decode(new Uint8Array(bytes));
 
-            this.menu.addMenuItem(new PopupMenu.PopupMenuItem('List of connected keyboards:'))
+    if (Array.isArray(bytes))
+        return UTF8_DECODER.decode(Uint8Array.from(bytes));
 
-            // Get the list of connected keyboards
-            let keyboards = this._getConnectedKeyboards()
+    return bytes?.toString?.() ?? '';
+}
 
-            if (keyboards.length === 0) {
-                let item = new PopupMenu.PopupMenuItem('No keyboards connected')
-                item.setSensitive(false)
-                this.menu.addMenuItem(item)
-            } else {
-                keyboards.forEach((keyboard) => {
-                    let toggleItem = new PopupMenu.PopupSwitchMenuItem(keyboard.name, true) // Create a toggle button for the keyboard
+const KEYBOARD_LIST_HEADING = 'List of connected keyboards:';
+const WAYLAND_UNSUPPORTED_MESSAGE = 'Keyboard control is not available while running under Wayland.';
+const XINPUT_MISSING_MESSAGE = 'The xinput command could not be found. Keyboard control is unavailable.';
 
-                    this.menu.addMenuItem(toggleItem)
+const KeyboardListMenu = GObject.registerClass(
+class KeyboardListMenu extends PanelMenu.Button {
+    constructor(extension) {
+        super(0.0, 'Keyboard cat defense');
 
-                    toggleItem.connect('toggled', (item) => {
-                        if (item.state) {
-                            this._enableKeyboard(keyboard.id)
-                        } else {
-                            this._disableKeyboard(keyboard.id)
-                        }
+        this._extension = extension;
+        this._sessionType = (GLib.getenv('XDG_SESSION_TYPE') ?? '').toLowerCase();
+        this._xinputAvailable = GLib.find_program_in_path('xinput') !== null;
+        this._supportsX11Session = this._sessionType === 'x11' || this._sessionType === '';
+        this._deviceControlAvailable = this._supportsX11Session && this._xinputAvailable;
 
-                        return Clutter.EVENT_STOP
-                    })
-                })
+        const icon = new St.Icon({
+            gicon: Gio.icon_new_for_string(`${this._extension.path}/cat.svg`),
+            style_class: 'cat-icon',
+        });
+        this.add_child(icon);
+
+        this.menu.addMenuItem(new PopupMenu.PopupMenuItem(KEYBOARD_LIST_HEADING));
+
+        this.menu.connect('open-state-changed', (_menu, open) => {
+            if (open && !this._initialized) {
+                this._updateKeyboardList();
+                this._initialized = true;
             }
-        }
-
-        /**
-         * Used to get the list of connected devices and filter for keyboards
-         * @return {Array} the list of keyboards
-         */
-        _getConnectedKeyboards() {
-            let [success, stdout, stderr] = GLib.spawn_command_line_sync('xinput list')
-            if (!success) {
-                log(`Error executing xinput list: ${stderr}`)
-                return []
-            }
-
-            let keyboards = []
-            let lines = stdout.toString().split('\n')
-
-            const keyboardIdRegex = /id=(\d+)/
-
-            // let masterKeyId
-            for (let line of lines) {
-                // get the master keyboard Id
-                // if (line.includes('master keyboard')) {
-                //     // if we detect the master key id
-                //     if (keyboardIdRegex.exec(line)) {
-                //         masterKeyId = keyboardIdRegex.exec(line)[1]
-                //     }
-                // }
-
-                if (line.includes('slave  keyboard')) {
-                    let parts = line.split('\t')
-
-                    // make sure the name also includes the word keyboard
-                    if (!parts[0].includes('keyboard')) {
-                        continue
-                    }
-
-                    // get the device ID
-                    let keyId = keyboardIdRegex.exec(line)
-                    if (keyId) {
-                        keyId = keyId[1]
-
-                        // for the keyboard name, trim the white space
-                        // and loose the first chars
-                        const keyboardName = parts[0].trim().slice(2)
-                        keyboards.push({
-                            name: keyboardName,
-                            id: keyId,
-                        })
-                    }
-
-                }
-            }
-
-            return keyboards
-        }
-
-        /**
-         * Disables a keyboard
-         * @param  {Number} keyboardId
-         */
-        _disableKeyboard(keyboardId) {
-            // Use xinput command to disable the keyboard with the given ID
-            let command = `xinput --disable ${keyboardId}`
-            let [success, stdout, stderr] = GLib.spawn_command_line_sync(command)
-
-            if (!success) {
-                log(`Error deactivating keyboard: ${stderr}`)
-            }
-        }
-
-        /**
-         * Enables a keboard
-         * @param  {Number} keyboardId
-         */
-        _enableKeyboard(keyboardId) {
-            // Use xinput command to enable the keyboard with the given ID
-            let command = `xinput --enable ${keyboardId}`
-            let [success, stdout, stderr] = GLib.spawn_command_line_sync(command)
-
-            if (!success) {
-                log(`Error enabling keyboard: ${stderr}`)
-            }
-        }
+        });
     }
-)
 
-let KeyboardListExtension = class KeyboardListExtension {
-    constructor() {}
+    /**
+     * Used to create the dropdown menu for the extension.
+     */
+    _updateKeyboardList() {
+        this.menu.removeAll();
 
+        this.menu.addMenuItem(new PopupMenu.PopupMenuItem(KEYBOARD_LIST_HEADING));
+
+        if (!this._deviceControlAvailable) {
+            const message = this._supportsX11Session ? XINPUT_MISSING_MESSAGE : WAYLAND_UNSUPPORTED_MESSAGE;
+            const item = new PopupMenu.PopupMenuItem(message);
+            item.setSensitive(false);
+            this.menu.addMenuItem(item);
+            return;
+        }
+
+        const keyboards = this._getConnectedKeyboards();
+
+        if (keyboards.length === 0) {
+            const item = new PopupMenu.PopupMenuItem('No keyboards connected');
+            item.setSensitive(false);
+            this.menu.addMenuItem(item);
+            return;
+        }
+
+        keyboards.forEach(keyboard => {
+            const toggleItem = new PopupMenu.PopupSwitchMenuItem(keyboard.name, true);
+            this.menu.addMenuItem(toggleItem);
+
+            toggleItem.connect('toggled', (item, state) => {
+                if (state) {
+                    this._enableKeyboard(keyboard.id);
+                } else {
+                    this._disableKeyboard(keyboard.id);
+                }
+
+                return Clutter.EVENT_STOP;
+            });
+        });
+    }
+
+    /**
+     * Used to get the list of connected devices and filter for keyboards.
+     * @return {Array} the list of keyboards.
+     */
+    _getConnectedKeyboards() {
+        if (!this._deviceControlAvailable)
+            return [];
+
+        const [success, stdout, stderr] = GLib.spawn_command_line_sync('xinput list');
+        if (!success) {
+            logError(new Error(`Error executing xinput list: ${bytesToString(stderr)}`));
+            return [];
+        }
+
+        const keyboards = [];
+        const lines = bytesToString(stdout).split('\n');
+        const keyboardIdRegex = /id=(\d+)/;
+
+        for (const line of lines) {
+            if (!line.includes('slave  keyboard'))
+                continue;
+
+            const parts = line.split('\t');
+
+            if (!parts[0].toLowerCase().includes('keyboard'))
+                continue;
+
+            const keyIdMatch = keyboardIdRegex.exec(line);
+            if (!keyIdMatch)
+                continue;
+
+            const keyboardName = parts[0].trim().slice(2);
+            keyboards.push({
+                name: keyboardName,
+                id: keyIdMatch[1],
+            });
+        }
+
+        return keyboards;
+    }
+
+    /**
+     * Disables a keyboard.
+     * @param {Number} keyboardId
+     */
+    _disableKeyboard(keyboardId) {
+        if (!this._deviceControlAvailable)
+            return;
+
+        const command = `xinput --disable ${keyboardId}`;
+        const [success, _stdout, stderr] = GLib.spawn_command_line_sync(command);
+
+        if (!success)
+            logError(new Error(`Error deactivating keyboard: ${bytesToString(stderr)}`));
+    }
+
+    /**
+     * Enables a keyboard.
+     * @param {Number} keyboardId
+     */
+    _enableKeyboard(keyboardId) {
+        if (!this._deviceControlAvailable)
+            return;
+
+        const command = `xinput --enable ${keyboardId}`;
+        const [success, _stdout, stderr] = GLib.spawn_command_line_sync(command);
+
+        if (!success)
+            logError(new Error(`Error enabling keyboard: ${bytesToString(stderr)}`));
+    }
+}
+);
+
+export default class KeyboardCatDefenseExtension extends Extension {
     enable() {
-        this._indicator = new KeyboardListMenu()
-        Main.panel.addToStatusArea('keyboard-list-menu', this._indicator, 0, 'right')
+        this._indicator = new KeyboardListMenu(this);
+        Main.panel.addToStatusArea('keyboard-list-menu', this._indicator, 0, 'right');
     }
 
     disable() {
-        this._indicator.destroy()
-        this._indicator = null
+        this._indicator?.destroy();
+        this._indicator = null;
     }
-}
-
-function init() {
-    return new KeyboardListExtension()
 }

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "Protect your keyboard with the most advance system. Disable the keyboard in seconds and continue using your system. The extension requires xinput as a dependency",
   "uuid": "keyboard-cat-defense@onel.github.io",
   "shell-version": [
-    "3.36", "43"
+    "3.36", "43", "45", "46", "47", "48"
   ],
   "url": "https://github.com/onel/keyboard-cat-defense",
   "version": 1


### PR DESCRIPTION
## Summary
- migrate the extension to the GNOME 45+ ES module format and add Wayland-aware fallbacks
- update metadata and add a reusable build script for packaging the extension
- configure GitHub Actions to build the archive and attach it to an automatic release on push
- replace the removed ByteArray resource import with a TextDecoder helper so the extension loads on GNOME 48

## Testing
- ./build.sh test.zip

------
https://chatgpt.com/codex/tasks/task_e_68e2dfb97b18832c9b53941968c7faae